### PR TITLE
Relax mypy pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
 ]
 dependencies = [
   "hatchling>=1.12.2",
-  "mypy~=0.971",
+  "mypy>=0.971",
   "pathspec",
   "setuptools",
 ]


### PR DESCRIPTION
This allows `hatch-mypyc` to be installed next to `mypy 1.0.1`.

## References

- fixes #30

## Changes

- uses the `>=` operator instead of `~=` for the `mypy` dependency