### PR TITLE
Update tests for hatchling 1.25

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v3

--- a/hatch.toml
+++ b/hatch.toml
@@ -26,17 +26,17 @@ detached = true
 dependencies = [
   "black>=22.10.0",
   "mypy>=0.991",
-  "ruff>=0.0.166",
+  "ruff>=0.5",
 ]
 [envs.lint.scripts]
 typing = "mypy --install-types --non-interactive {args:hatch_mypyc tests}"
 style = [
-  "ruff {args:.}",
+  "ruff check {args:.}",
   "black --check --diff {args:.}",
 ]
 fmt = [
   "black {args:.}",
-  "ruff --fix {args:.}",
+  "ruff format {args:.}",
   "style",
 ]
 all = [

--- a/hatch_mypyc/plugin.py
+++ b/hatch_mypyc/plugin.py
@@ -144,7 +144,7 @@ class MypycBuildHook(BuildHookInterface):
         if self.__package_source is None:
             if self.build_config.sources:
                 # Just support one source for now
-                self.__package_source = list(self.build_config.sources)[0][:-1]
+                self.__package_source = next(iter(self.build_config.sources))[:-1]
             else:
                 self.__package_source = ''
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,8 @@ skip-string-normalization = true
 [tool.ruff]
 target-version = "py37"
 line-length = 120
+
+[tool.ruff.lint]
 select = [
   "A",
   "B",
@@ -93,16 +95,16 @@ unfixable = [
   "F401",
 ]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["hatch_mypyc"]
 
-[tool.ruff.flake8-quotes]
+[tool.ruff.lint.flake8-quotes]
 inline-quotes = "single"
 
-[tool.ruff.flake8-tidy-imports]
+[tool.ruff.lint.flake8-tidy-imports]
 ban-relative-imports = "all"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 # Tests can use relative imports and assertions
 "tests/**/*" = ["TID252", "S101"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,8 @@ ignore = [
   "FBT003",
   # Ignore checks for possible passwords
   "S105", "S106", "S107",
+  # Ignore false-positive subprocess check (https://github.com/astral-sh/ruff/issues/4045)
+  "S603",
 ]
 unfixable = [
   # Don't touch unused imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "hatch-mypyc"
 description = "Hatch build hook plugin for Mypyc"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 license = "MIT"
 keywords = [
   "build",
@@ -24,11 +24,11 @@ classifiers = [
   "Framework :: Hatch",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: Implementation :: CPython",
   "Programming Language :: Python :: Implementation :: PyPy",
   "Topic :: Software Development :: Build Tools",

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -8,6 +8,8 @@ from packaging.tags import sys_tags
 
 from .utils import build_project
 
+best_matching_tag = next(iter(t for t in sys_tags() if 'manylinux' not in t.platform and 'musllinux' not in t.platform))
+
 
 def test_target_not_wheel(new_project):
     project_file = new_project / 'pyproject.toml'
@@ -36,7 +38,6 @@ def test_no_exclusion(new_project, compiled_extension):
     assert len(artifacts) == 1
     wheel_file = artifacts[0]
 
-    best_matching_tag = next(sys_tags())
     assert wheel_file.name == f'my_app-1.2.3-{best_matching_tag}.whl'
 
     extraction_directory = new_project.parent / '_archive'
@@ -100,7 +101,6 @@ if __name__ == '__main__':
     assert len(artifacts) == 1
     wheel_file = artifacts[0]
 
-    best_matching_tag = next(sys_tags())
     assert wheel_file.name == f'my_app-1.2.3-{best_matching_tag}.whl'
 
     extraction_directory = new_project.parent / '_archive'
@@ -154,7 +154,6 @@ def test_separation(new_project):
     assert len(artifacts) == 1
     wheel_file = artifacts[0]
 
-    best_matching_tag = next(sys_tags())
     assert wheel_file.name == f'my_app-1.2.3-{best_matching_tag}.whl'
 
     extraction_directory = new_project.parent / '_archive'
@@ -211,7 +210,6 @@ def test_src_layout(new_project, compiled_extension):
     assert len(artifacts) == 1
     wheel_file = artifacts[0]
 
-    best_matching_tag = next(sys_tags())
     assert wheel_file.name == f'my_app-1.2.3-{best_matching_tag}.whl'
 
     extraction_directory = new_project.parent / '_archive'
@@ -278,7 +276,6 @@ import {dependency}
     assert len(artifacts) == 1
     wheel_file = artifacts[0]
 
-    best_matching_tag = next(sys_tags())
     assert wheel_file.name == f'my_app-1.2.3-{best_matching_tag}.whl'
 
     extraction_directory = new_project.parent / '_archive'
@@ -334,7 +331,6 @@ def test_build_dir(new_project, compiled_extension):
     assert len(artifacts) == 1
     wheel_file = artifacts[0]
 
-    best_matching_tag = next(sys_tags())
     assert wheel_file.name == f'my_app-1.2.3-{best_matching_tag}.whl'
 
     extraction_directory = new_project.parent / '_archive'

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -210,7 +210,13 @@ class TestPatternMatching:
             'tool': {
                 'hatch': {
                     'build': {
-                        'targets': {'wheel': {'exclude': ['foo'], 'hooks': {'mypyc': {}}}},
+                        'targets': {
+                            'wheel': {
+                                'exclude': ['foo'],
+                                'hooks': {'mypyc': {}},
+                                'include': ['bar'],
+                            },
+                        },
                     },
                 },
             },
@@ -244,7 +250,13 @@ class TestPatternMatching:
             'tool': {
                 'hatch': {
                     'build': {
-                        'targets': {'wheel': {'exclude': ['foo'], 'hooks': {'mypyc': {'exclude': ['baz.py']}}}},
+                        'targets': {
+                            'wheel': {
+                                'exclude': ['foo'],
+                                'hooks': {'mypyc': {'exclude': ['baz.py']}},
+                                'include': ['bar'],
+                            }
+                        },
                     },
                 },
             },


### PR DESCRIPTION
ofek/hatch#1438 changed the default tag selection in hatchling:

> Linux tag is after many/musl; packaging tools are required to skip
> many/musl, see https://github.com/pypa/packaging/issues/160

While I'm here, and to get CI to pass:
1. Update the supported Python versions.
2. Add some explicit includes to `test_config`.
3. Upgrade ruff to 0.5.0